### PR TITLE
fixed at_hash and c_hash encoding

### DIFF
--- a/src/main/java/com/bornium/security/oauth2openid/Util.java
+++ b/src/main/java/com/bornium/security/oauth2openid/Util.java
@@ -32,6 +32,6 @@ public class Util {
         byte[] result = new byte[hash.length / 2];
         for (int i = 0; i < hash.length / 2; i++)
             result[i] = hash[i];
-        return UriUtil.encode(Base64.getEncoder().encodeToString(result));
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(result);
     }
 }


### PR DESCRIPTION
The "base64url" e.g. in https://openid.net/specs/openid-connect-core-1_0.html#CodeIDToken is a variant of the usual base64 algorithm described in https://datatracker.ietf.org/doc/html/rfc4648#section-5 (not to be mixed up with base64 and then URL-encoding).